### PR TITLE
增加查看修改用户信息界面

### DIFF
--- a/Yishuwang/urls.py
+++ b/Yishuwang/urls.py
@@ -50,4 +50,5 @@ urlpatterns = [
     url(r'^upload_book$',app.views.upload_book),
     url(r'^user_book_detail$',app.views.user_book_detail),
     url(r'^delete_book/(?P<book_id>\d+)',app.views.delete_book)
+    url(r'^personal_inf$',app.views.personal_inf, name='inf'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/app/admin.py
+++ b/app/admin.py
@@ -4,7 +4,7 @@ from app.models import book , UserProfile
 
   
 class UserProfileAdmin(admin.ModelAdmin):  
-    fields = ('user','description',)  
+    fields = ('user',‘school','description',)  
   
 admin.site.register(UserProfile, UserProfileAdmin)
 

--- a/app/models.py
+++ b/app/models.py
@@ -8,8 +8,8 @@ from django.db.models.signals import post_save
 
 class UserProfile(models.Model):  
     user = models.OneToOneField(User) 
-    school = models.TextField(max_length=50,default='')
-    description = models.TextField(max_length=51200,default='') 
+    school = models.TextField(max_length=50,default='blank')
+    description = models.TextField(max_length=51200,default='blank') 
     
     def __str__(self):
         return self.user.username 

--- a/app/models.py
+++ b/app/models.py
@@ -7,8 +7,9 @@ from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 
 class UserProfile(models.Model):  
-    user = models.OneToOneField(User)  
-    description = models.TextField(max_length=51200)   
+    user = models.OneToOneField(User) 
+    school = models.TextField(max_length=50,default='')
+    description = models.TextField(max_length=51200,default='')   
   
 def create_user_profile(sender, instance, created, **kwargs):  
     if created:  

--- a/app/models.py
+++ b/app/models.py
@@ -9,7 +9,10 @@ from django.db.models.signals import post_save
 class UserProfile(models.Model):  
     user = models.OneToOneField(User) 
     school = models.TextField(max_length=50,default='')
-    description = models.TextField(max_length=51200,default='')   
+    description = models.TextField(max_length=51200,default='') 
+    
+    def __str__(self):
+        return self.user.username 
   
 def create_user_profile(sender, instance, created, **kwargs):  
     if created:  

--- a/app/templates/app/loginpartial.html
+++ b/app/templates/app/loginpartial.html
@@ -5,6 +5,7 @@
         <li><span class="navbar-brand">您好 {{ user.username }}!</span></li>
         <li><a href="upload_book"> 发布旧书</a></li>
         <li><a href="user_book_detail" >查看我的书籍</a></li>
+        <li><a href="{% url 'inf' %}" >个人信息</a></li>
         <li><a href="javascript:document.getElementById('logoutForm').submit()">登出</a></li>
     </ul>
 

--- a/app/templates/app/personal_inf.html
+++ b/app/templates/app/personal_inf.html
@@ -1,0 +1,55 @@
+﻿{% extends "app/layout.html" %}
+
+{% block content %}
+
+{% if user.is_authenticated %}
+<h2>{{ title }}</h2>
+<div class="row">
+    <div class="col-md-8">
+        <section>
+            <form action="" method="post" class="form-horizontal">
+                {% csrf_token %}
+                <h4>你可以查看或修改您的信息。</h4>
+ 
+                <hr />
+                <div class="form-group">
+                    <label for="id_username" class="col-md-2 control-label">用户名</label>
+                    <div class="col-md-10">
+                        <font size="5" > {{ user.username }}</font>                      
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="id_email" class="col-md-2 control-label">e-mail</label>
+                    <div class="col-md-10">
+                        <input type="text", value={{ user.email }} name="email" />                  
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="id_password" class="col-md-2 control-label">学校</label>
+                    <div class="col-md-10">
+                        <input type="text", value={{ user.userprofile.school }} name="school" /> 
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="id_password" class="col-md-2 control-label">个人描述</label>
+                    <div class="col-md-10">
+                        <input type="text", value={{ user.userprofile.description }} name="description" /> 
+                    </div>
+                </div>
+                
+                <div class="form-group">
+                    <div class="col-md-offset-2 col-md-10">
+                        <input type = 'submit'  value="保存" class="btn btn-default" /> 
+                        <a href="{% url 'home' %}" >取消</a>
+                    </div>
+                </div>
+                {% for items in errors %}
+                <p class="validation-summary-errors"> {{items}} </p>
+                {% endfor %}
+            </form>
+        </section>
+    </div>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -9,11 +9,20 @@ from django.template import RequestContext
 from datetime import datetime
 from django.shortcuts import render_to_response
 from django.contrib.auth.models import User
-from app.models import book
+from app.models import book, UserProfile
 from django.template import RequestContext
 from django.contrib import auth
 
 from django import forms
+
+class InfForm(forms.Form):
+    email = forms.EmailField(label='e-mail',widget=forms.TextInput({
+                                   'class': 'form-control',
+                                   'placeholder': 'e-mail'}))
+    school = forms.CharField(max_length=50)
+    description = forms.CharField(max_length=51200)
+
+
 class RegisterForm(forms.Form):
     username = forms.CharField(max_length=254,
                                widget=forms.TextInput({
@@ -30,6 +39,37 @@ class RegisterForm(forms.Form):
                                widget=forms.PasswordInput({
                                    'class': 'form-control',
                                    'placeholder':'Password'}))
+
+
+class BookForm(forms.Form):
+    name_book = forms.CharField(max_length=50)
+    #年级的下拉框
+    grade_choices = (
+        ('大一上', '大一上'),
+        ('大一下', '大一下'),
+        ('大二上', '大二上'),
+        ('大二下', '大二下'),
+        ('大三上', '大三上'),
+        ('大三下', '大三下'),
+        ('大四上', '大四上'),
+        ('大四下', '大四下'),
+    )
+    grade_book = forms.ChoiceField(choices=grade_choices)
+    discount_choices =(
+        ('1', '一折'),
+        ('2', '二折'),
+        ('3', '三折'),
+    )
+    discount_book = forms.ChoiceField(choices=discount_choices)
+
+    major_choice = (
+        ('信息安全', '信息安全'),
+        ('软件工程', '软件工程'),
+        ('计算机', '计算机'),
+    )
+
+    major_book = forms.ChoiceField(choices=major_choice)
+    photo_book = forms.FileField()
 
 
 def home(request):
@@ -105,35 +145,6 @@ def register(request):
     return render(request, "app/register.html")
 
 
-class BookForm(forms.Form):
-    name_book = forms.CharField(max_length=50)
-    #年级的下拉框
-    grade_choices = (
-        ('大一上', '大一上'),
-        ('大一下', '大一下'),
-        ('大二上', '大二上'),
-        ('大二下', '大二下'),
-        ('大三上', '大三上'),
-        ('大三下', '大三下'),
-        ('大四上', '大四上'),
-        ('大四下', '大四下'),
-    )
-    grade_book = forms.ChoiceField(choices=grade_choices)
-    discount_choices =(
-        ('1', '一折'),
-        ('2', '二折'),
-        ('3', '三折'),
-    )
-    discount_book = forms.ChoiceField(choices=discount_choices)
-
-    major_choice = (
-        ('信息安全', '信息安全'),
-        ('软件工程', '软件工程'),
-        ('计算机', '计算机'),
-    )
-
-    major_book = forms.ChoiceField(choices=major_choice)
-    photo_book = forms.FileField()
 
 
 def upload_book(request):
@@ -161,6 +172,7 @@ def upload_book(request):
     else:
         return HttpResponseRedirect('/login')
 
+
 def user_book_detail(request):
     if request.user.is_authenticated:
         user = request.user
@@ -173,6 +185,7 @@ def user_book_detail(request):
     else:
         return HttpResponseRedirect('/login')
 
+
 #通过传递参数book_id 来达到删除书的目的
 def delete_book(request,book_id):
     book_id = book_id
@@ -183,4 +196,27 @@ def delete_book(request,book_id):
     else:
         return HttpResponseRedirect('/login')
     return HttpResponseRedirect('/user_book_detail')
+
+def personal_inf(request):
+    if request.user.is_authenticated:
+        profile = request.user.userprofile
+        if request.method=='POST': 
+            form=InfForm(request.POST)
+
+            if not form.is_valid():
+               return render(request, "app/personal_inf.html",{'form':form,'title':'个人信息','year':datetime.now().year,})
+            email = form.cleaned_data['email']
+            school = form.cleaned_data['school']
+            description= form.cleaned_data['description']
+        
+            profile.user.email = email
+            profile.school = school
+            profile.description = description
+            profile.save()
+            return HttpResponseRedirect("/")
+        else:
+            form =InfForm()
+            return render(request, "app/personal_inf.html",{'form':form,'title':'个人信息','year':datetime.now().year,})
+    return render(request, "app/personal_inf.html")
+        
 


### PR DESCRIPTION
用户扩展信息暂定为school和description，以后可以修改。
完全没有考虑美化问题，只实现基本功能。
用法：
菜单栏点击“个人信息”
跳转页面中的输入框内默认为当前信息，修改后点击保存提交，点击取消返回主页
